### PR TITLE
新增 Ollama 地端模型支援，讓使用者無需 API Key 即可在本機或內部伺服器自架 AI 進行 PR 審查，保護程式碼隱私

### DIFF
--- a/README-Dev.md
+++ b/README-Dev.md
@@ -37,7 +37,8 @@ d:\Project\AiPrCodeReview
 │   │   ├── openai.service.ts                 # OpenAI 服務實作
 │   │   ├── grok.service.ts                   # Grok (xAI) 服務實作
 │   │   ├── claude.service.ts                 # Claude (Anthropic) 服務實作
-│   │   └── github-copilot.service.ts         # GitHub Copilot 服務實作
+│   │   ├── github-copilot.service.ts         # GitHub Copilot 服務實作
+│   │   └── ollama.service.ts                 # Ollama 地端 AI 服務實作
 │   ├── index.ts             # 主程式進入點
 │   └── task.json            # Azure Pipeline Task 定義檔
 ├── package.json             # npm 套件設定
@@ -111,7 +112,7 @@ npx ts-node DEVSCRIPTS/test-pr-review.ts [參數]
 **注意**：`--github-token` 和 `--server-address` 不能同時使用 
 
 **AI 提供者參數**：
-- `--ai <PROVIDER>` - AI 提供者：'claude', 'openai', 'grok', 'google'（預設：claude）
+- `--ai <PROVIDER>` - AI 提供者：'claude', 'openai', 'grok', 'google', 'ollama'（預設：claude）
 - `--model <MODEL_NAME>` - 模型名稱（例如：claude-haiku-4-5、gpt-5-mini、gemini-2.5-flash）
 - `--key <API_KEY>` - API Key（或使用環境變數）
 
@@ -209,6 +210,21 @@ npx ts-node DEVSCRIPTS/test-pr-review.ts \
   --throttle true
 ```
 
+7. **Azure DevOps + Ollama（地端模型）**
+```bash
+npx ts-node DEVSCRIPTS/test-pr-review.ts \
+  --provider azure \
+  --token Your_AzureDevops_Token \
+  --pr 20 \
+  --org https://dev.azure.com/myorg \
+  --project MyProject \
+  --repo-id 94408af5-6c38-45d2-a5d3-cbcfd38b8ae7 \
+  --ai ollama \
+  --model gemma3:27b \
+  --base-url http://127.0.0.1:11434 \
+  --throttle true
+```
+
 **輸出說明**：
 - 顯示當前配置設定
 - 取得 PR 變更檔案（顯示檔案數量、檔案大小、Token 數量）
@@ -300,11 +316,13 @@ npx ts-node devscripts/inline-comment.ts \
 | DevOpsProjectName | 必要 | YourProject | Azure DevOps 專案名稱 |
 | DevOpsRepositoryId | 必要 | 00000000-0000-0000-0000-000000000000 | Repository ID（或在某些實作中可用 repo 名稱） |
 | DevOpsPRId | 必要 | 4 | 要測試的 Pull Request 編號 |
-| AiProvider | 必要 | Google | 在 `AIProviderService` 中註冊的 provider 名稱（例如 `Google`、`OpenAI`、`Grok`） |
+| AiProvider | 必要 | Google | 在 `AIProviderService` 中註冊的 provider 名稱（例如 `Google`、`OpenAI`、`Grok`、`Ollama`） |
 | GeminiAPIKey | 選用 | AI_KEY | Gemi API Key，若使用 Google 時，此欄位必填 |
 | OpenAIAPIKey | 選用 | sk-... | OpenAI API Key，若使用 OpenAI 時，此欄位必填 |
 | GrokAPIKey | 選用 | xai-... | Grok (xAI) API Key，若使用 Grok 時，此欄位必填 |
 | ClaudeAPIKey | 選用 | sk-ant-... | Claude API Key，若使用 Claude 時，此欄位必填 |
+| OllamaModelName | 選用 | gemma3:27b | Ollama 模型名稱（例如 llama3.2:3b、gemma3:27b），若使用 Ollama 時，此欄位必填 |
+| OllamaBaseUrl | 選用 | http://localhost:11434 | Ollama 伺服器 Base URL（預設 http://localhost:11434），無需 API Key |
 | GitHubCopilotToken | 選用 | github_pat_xxx | GitHub Fine-grained Personal Access Token（格式：github_pat_xxx），用於 Token 模式認證。**不能與 GitHubCopilotServerAddress 同時使用** |
 | GitHubCopilotServerAddress | 選用 | localhost:8080 | GitHub Copilot CLI Server 位址（格式: host:port）。若未提供且未提供 Token，將使用本機的 GitHub Copilot CLI（需先完成 `copilot auth login`）。**不能與 GitHubCopilotToken 同時使用** |
 | GitHubCopilotCliPath | 選用 | C:\Tools\copilot\copilot.exe | GitHub Copilot CLI 執行檔的絕對路徑。若為空，依序嘗試環境變數 `COPILOT_CLI_PATH`，再嘗試系統 PATH |
@@ -334,13 +352,19 @@ DevOpsProjectName=YourProject
 DevOpsRepositoryId=00000000-0000-0000-0000-000000000000
 DevOpsPRId=4
 
-# AI Provider (選擇其一：Google / OpenAI / Grok / Claude / GitHubCopilot)
+# AI Provider (選擇其一：Google / OpenAI / Grok / Claude / GitHubCopilot / Ollama)
 GeminiAPIKey=PASTE_YOUR_GEMINI_KEY
 OpenAIAPIKey=PASTE_YOUR_OPENAI_KEY
 GrokAPIKey=PASTE_YOUR_GROK_KEY
 ClaudeAPIKey=PASTE_YOUR_CLAUDE_KEY
 AiProvider=Google
 ModelName=gemini-2.5-flash
+
+# Ollama（地端模型，無需 API Key，三選一：本機 / 遠端伺服器 / 自訂 Base URL）
+# AiProvider=Ollama
+# OllamaModelName=gemma3:27b
+# OllamaBaseUrl=http://localhost:11434
+# OllamaBaseUrl=http://127.0.0.1:11434
 
 # GitHub Copilot 認證模式（三選一，不能同時使用）：
 # 模式 1: Token 模式（雲端 CI）

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ This is an Azure DevOps Pipeline extension that leverages the power of Large Lan
 + **Google Gemini**
 + **Anthropic Claude**
 + **xAI Grok**
++ **Ollama** (Local deployment, any Ollama-compatible model)
 
 > **Highlight**: Maximize the value of your existing **GitHub Copilot** subscription by integrating it directly into your Azure DevOps PR workflow! This extension also supports GitHub repository Pull Request CI.
 
 
 ## ✨ Main Features
 + **Automated PR review**: Automatically triggers during PR build validation, acting as a diligent 24/7 reviewer.
-+ **Universal AI Support**: Seamlessly switch between Google Gemini, OpenAI, Grok, Claude, and GitHub Copilot based on your needs.
++ **Universal AI Support**: Seamlessly switch between Google Gemini, OpenAI, Grok, Claude, GitHub Copilot, and self-hosted Ollama based on your needs.
 + **GitHub Copilot Integration**: Connect to GitHub Copilot CLI to perform reviews using your existing subscription (Individual, Business, or Enterprise), ensuring data privacy and cost-efficiency.
 + **Direct Feedback**: Publishes AI review suggestions directly to the PR as comments, threading into the conversation.
 + **Highly Customizable**: Tailor the System Prompts (Built-in, Inline, or File-based), adjust creativity (Temperature), and control token usage.
@@ -40,6 +41,7 @@ Different AI Providers have different prerequisites:
 | Grok (xAI) | Apply for API Key | Get API Key from [xAI Console](https://console.x.ai/) |
 | Claude (Anthropic) | Apply for API Key | Get API Key from [Anthropic Console](https://console.anthropic.com/) |
 | **GitHub Copilot** | GitHub Token or CLI Setup | See [GitHub Copilot Prerequisites](#github-copilot-prerequisites) below |
+| **Ollama** | Local deployment (no API Key required) | Deploy [Ollama](https://ollama.com/) locally or on an internal server |
 
 ### GitHub Copilot Prerequisites
 
@@ -218,7 +220,7 @@ For detailed review mode parameter combinations, see [PARAMETER-COMBINATIONS.md]
   
 | Label | Type | Required | Default | Description |
 |---|---:|:---:|---|---|
-| AI Provider | pickList | Yes | Google | Choose the AI platform to generate comments. Options: Google (Google Gemini), OpenAI, Grok (xAI), Claude (Anthropic), GitHub Copilot. |
+| AI Provider | pickList | Yes | Google | Choose the AI platform to generate comments. Options: Google (Google Gemini), OpenAI, Grok (xAI), Claude (Anthropic), GitHub Copilot, Ollama (Local). |
 | Gemini Model Name | string | Conditional | gemini-2.5-flash | Enter the Google Gemini model name. Required when AI Provider is Google. |
 | Gemini API Key | string | Conditional | (empty) | Enter the Google Gemini API Key. Required when AI Provider is Google. |
 | OpenAI Model Name | string | Conditional | gpt-5-mini | Enter the OpenAI model name (e.g., gpt-5-mini). Required when AI Provider is OpenAI. |
@@ -232,6 +234,8 @@ For detailed review mode parameter combinations, see [PARAMETER-COMBINATIONS.md]
 | GitHub Copilot Model Name | string | No | gpt-5-mini | Enter the model name used by GitHub Copilot. Optional, defaults to gpt-5-mini. Visible when GitHub Copilot is selected. |
 | GitHub Copilot Request Timeout (ms) | string | No | 300000 | Request timeout in milliseconds for GitHub Copilot. Default: 300000 ms (5 minutes). Visible when GitHub Copilot is selected. |
 | GitHub Copilot CLI Path | string | No | (empty) | (Optional) Absolute path to the Copilot CLI executable on the build agent. Example (Windows): `C:\Tools\copilot\copilot.exe`. If empty, falls back to environment variable `COPILOT_CLI_PATH`, then system PATH. Visible when GitHub Copilot is selected. |
+| Ollama Model Name | string | Conditional | (empty) | Enter the Ollama model name (e.g. llama3.2:3b, gemma3:27b). Required when AI Provider is Ollama. Visible when Ollama is selected. |
+| Ollama Base URL | string | No | http://localhost:11434 | Enter the Ollama server base URL (e.g. http://localhost:11434 or http://127.0.0.1:11434). No API Key required. Defaults to http://localhost:11434. Visible when Ollama is selected. |
 | System Instruction Source | pickList | Yes | Built-in | Select the source of the system instruction. Options: Built-in (uses a built-in optimized code review prompt), Inline, File. |
 | System Prompt File | string | No | (empty) | Path to the system prompt file. Supported formats: .md, .txt, .json, .yaml, .yml, .xml, .html. Optional. If the file is not found or empty, falls back to inline instruction. |
 | System Instruction | multiLine | No | You are a senior software engineer. Please help... (see Task defaults) | System-level instruction used to guide the AI model's behavior. Used when System Instruction Source is 'Inline'. Optional. If empty, a default code review instruction will be used automatically. |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -9,13 +9,14 @@
 + **Google Gemini**
 + **Anthropic Claude**
 + **xAI Grok**
++ **Ollama**（地端部署，支援任意 Ollama 相容模型）
 
 > **特色亮點**：現已支援 **GitHub Copilot**！您可以直接利用現有的 GitHub Copilot 訂閱（不分版本），將 AI 審查能力無縫整合進 Azure DevOps 流程中。本套件亦支援針對 GitHub 儲存庫的 Pull Request CI 情境。
 
 
 ## ✨ 主要功能
 + **自動化 PR 審查**：在 PR 建置驗證 (Build Validation) 過程中自動觸發，提供 24/7 的程式碼把關。
-+ **多模型支援**：單一套件完整支援 Google Gemini、OpenAI、Grok、Claude 與 GitHub Copilot，可依需求彈性切換。
++ **多模型支援**：單一套件完整支援 Google Gemini、OpenAI、Grok、Claude、GitHub Copilot 與自架 Ollama，可依需求彈性切換。
 + **GitHub Copilot 深度整合**：支援連接 GitHub Copilot CLI Server，直接重用現有的訂閱 (Individual/Business/Enterprise)，兼顧成本與隱私。
 + **直接回饋**：將 AI 的審查建議直接以評論形式發佈到 PR 中，與開發團隊無縫協作。
 + **高度可自訂**：可詳盡自訂 AI 的系統提示 (System Prompt)、模型參數 (Temperature 等)，打造專屬的 AI Reviewer。
@@ -39,6 +40,7 @@
 | Grok (xAI) | 申請 API Key | 從 [xAI Console](https://console.x.ai/) 獲取 API Key |
 | Claude (Anthropic) | 申請 API Key | 從 [Anthropic Console](https://console.anthropic.com/) 獲取 API Key |
 | **GitHub Copilot** | GitHub Token 或 CLI 設定 | 請參考下方 [GitHub Copilot 前置作業](#github-copilot-前置作業) |
+| **Ollama** | 地端部署（無需 API Key） | 在本機或內部伺服器部署 [Ollama](https://ollama.com/) |
 
 ### GitHub Copilot 前置作業
 
@@ -217,7 +219,7 @@
 
 | 標籤 (Label) | 類型 (Type) | 必要 | 預設值 | 說明 |
 |---|---:|:---:|---|---|
-| AI Provider | pickList | 是 | Google | 選擇要用於產生評論的 AI 平台。選項: Google (Google Gemini)、OpenAI、Grok (xAI)、Claude (Anthropic)、GitHub Copilot。 |
+| AI Provider | pickList | 是 | Google | 選擇要用於產生評論的 AI 平台。選項: Google (Google Gemini)、OpenAI、Grok (xAI)、Claude (Anthropic)、GitHub Copilot、Ollama (Local)。 |
 | Gemini Model Name | string | 條件式 | gemini-2.5-flash | 輸入 Google Gemini 的模型名稱，選擇 Google 時必填。 |
 | Gemini API Key | string | 條件式 | 無 | 輸入 Google Gemini 的 API Key，選擇 Google 時必填。 |
 | OpenAI Model Name | string | 條件式 | gpt-5-mini | 輸入 OpenAI 的模型名稱（例如 gpt-5、gpt-5-mini），選擇 OpenAI 時必填。 |
@@ -231,6 +233,8 @@
 | GitHub Copilot Model Name | string | 否 | gpt-5-mini | 輸入 GitHub Copilot 使用的模型名稱。選填，預設為 gpt-5-mini。選擇 GitHub Copilot 時顯示。 |
 | GitHub Copilot Request Timeout (ms) | string | 否 | 300000 | GitHub Copilot 的請求逾時時間（毫秒）。預設值：300000 ms（5 分鐘）。選擇 GitHub Copilot 時顯示。 |
 | GitHub Copilot CLI Path | string | 否 | 無 | （選填）Build Agent 上 Copilot CLI 執行檔的絕對路徑。範例（Windows）：`C:\Tools\copilot\copilot.exe`。若為空，依序嘗試環境變數 `COPILOT_CLI_PATH`，再嘗試系統 PATH。選擇 GitHub Copilot 時顯示。 |
+| Ollama Model Name | string | 條件式 | 無 | 輸入 Ollama 的模型名稱（例如 llama3.2:3b、gemma3:27b）。選擇 Ollama 時必填。選擇 Ollama 時顯示。 |
+| Ollama Base URL | string | 否 | http://localhost:11434 | 輸入 Ollama 伺服器的基礎 URL（例如 http://localhost:11434 或 http://127.0.0.1:11434）。無需 API Key，預設為 http://localhost:11434。選擇 Ollama 時顯示。 |
 | System Instruction Source | pickList | 是 | Built-in | 選擇系統指令的來源。選項: Built-in (內建), Inline (行內), File (檔案)。 |
 | System Prompt File | string | 否 | 無 | 系統提示詞檔案的路徑。支援格式: .md, .txt, .json, .yaml, .yml, .xml, .html。選填。如果檔案不存在或為空，會自動回退到行內指令。 |
 | System Instruction | multiLine | 否 | You are a senior software engineer. Please help... | 用於指導 AI 模型行為的系統級指令。當 System Instruction Source 選擇 'Inline' 時使用。選填。如果為空，系統會自動使用預設的 Code Review 指令。 |

--- a/devscripts/.env
+++ b/devscripts/.env
@@ -25,14 +25,16 @@ OpenAIAPIKey=YourOpenAIAPIKey
 GrokAPIKey=YourGrokAPIKey
 # Anthropic Claude API key | Claude (Anthropic) API 金鑰
 ClaudeAPIKey=YourClaudeAPIKey
-# AI provider to use | 使用的 AI 供應商 (Google / OpenAI / Grok / Claude / GitHubCopilot)
-AiProvider=GitHubCopilot
+# AI provider to use | 使用的 AI 供應商 (Google / OpenAI / Grok / Claude / GitHubCopilot / Ollama)
+AiProvider=Ollama
 # Model name for selected provider | 所選供應商的模型名稱
 # Available model reference names | 可用模型參考名稱:
-#   gemini-2.5-flash / grok-3-mini
+#   gemini-2.5-flash / grok-3-mini / gemini-3-flash-preview
 #   gpt-4.1 / gpt-5-mini / gpt-5.4
 #   claude-haiku-4.5 / claude-sonnet-4.5 / claude-sonnet-4.6 / claude-opus-4.5
-ModelName=gpt-5-mini
+#   gemma3:27b / gemma4:e4b
+# ModelName=Claude Haiku 4.5
+ModelName=gemma3:27b
 
 # ============================================================
 # GitHub Copilot Settings | GitHub Copilot 特殊設定
@@ -44,6 +46,13 @@ ModelName=gpt-5-mini
 GitHubCopilotToken=YourGitHubCopilotToken
 # Request timeout in milliseconds | 請求逾時（毫秒），預設 300000ms（5 分鐘）
 GitHubCopilotTimeout=300000
+
+# ============================================================
+# Ollama Settings | Ollama 地端模型設定
+# Configure Ollama local model server | 設定 Ollama 地端模型伺服器
+# ============================================================
+# Ollama server base URL | Ollama 伺服器基礎 URL
+OllamaBaseUrl=http://localhost:11434
 
 # ============================================================
 # AI Generation Settings | AI 生成設定

--- a/devscripts/ai-comment.ts
+++ b/devscripts/ai-comment.ts
@@ -51,6 +51,13 @@ async function run() {
                 githubToken: process.env.GitHubCopilotToken ?? '',
                 serverAddress: process.env.GitHubCopilotServerAddress ?? ''
             };
+        } else if (providerKey === AI_PROVIDERS.OLLAMA) {
+            canonicalName = AI_PROVIDER_DISPLAY_NAMES[AI_PROVIDERS.OLLAMA];
+            registerConfig = {
+                apiKey: '', // Ollama 不需要 API Key
+                modelName: process.env.ModelName ?? DEFAULT_MODELS[AI_PROVIDERS.OLLAMA] ?? '',
+                serverAddress: process.env.OllamaBaseUrl ?? 'http://localhost:11434'
+            };
         } else {
             throw new Error(`⛔ Unsupported AI Provider: ${requested}`);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aiprcodereview",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "aiprcodereview",
-            "version": "2.0.6",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "@github/copilot-sdk": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aiprcodereview",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "keywords": [
         "AI pull request code review",
         "Azure DevOps Pipeline",

--- a/src/constants/models.constants.ts
+++ b/src/constants/models.constants.ts
@@ -6,7 +6,8 @@ export const DEFAULT_MODELS: Record<string, string> = {
   [AI_PROVIDERS.GROK]: 'grok-3-mini',
   [AI_PROVIDERS.CLAUDE]: 'claude-haiku-4-5',
   [AI_PROVIDERS.GOOGLE]: 'gemini-2.5-flash',
-  [AI_PROVIDERS.GITHUB_COPILOT]: 'gpt-5-mini'       // 統一使用 gpt-5-mini
+  [AI_PROVIDERS.GITHUB_COPILOT]: 'gpt-5-mini',       // 統一使用 gpt-5-mini
+  [AI_PROVIDERS.OLLAMA]: ''                          // 用戶自行指定模型
 };
 
 // Environment variable key 映射（原 index.ts line 141-147）
@@ -15,7 +16,8 @@ export const API_KEY_ENV_MAP: Record<string, string> = {
   [AI_PROVIDERS.GROK]: 'GrokAPIKey',
   [AI_PROVIDERS.CLAUDE]: 'ClaudeAPIKey',
   [AI_PROVIDERS.GOOGLE]: 'GeminiAPIKey',
-  [AI_PROVIDERS.GITHUB_COPILOT]: '' // 不需要 API Key
+  [AI_PROVIDERS.GITHUB_COPILOT]: '', // 不需要 API Key
+  [AI_PROVIDERS.OLLAMA]: ''           // 不需要 API Key
 };
 
 // Task input 配置映射（原 index.ts line 152-158）
@@ -74,5 +76,11 @@ export const TASK_INPUT_CONFIG_MAP: Record<string, TaskInputConfig> = {
     githubTokenKey: 'inputGitHubCopilotToken',
     serverAddressKey: 'inputGitHubCopilotServerAddress',
     copilotCliPathKey: 'inputGitHubCopilotCliPath'
+  },
+  [AI_PROVIDERS.OLLAMA]: {
+    nameKey: 'inputOllamaModelName',
+    apiKeyKey: '',
+    defaultName: DEFAULT_MODELS[AI_PROVIDERS.OLLAMA],
+    serverAddressKey: 'inputOllamaBaseUrl'
   }
 };

--- a/src/constants/providers.constants.ts
+++ b/src/constants/providers.constants.ts
@@ -4,7 +4,8 @@ export const AI_PROVIDERS = {
   GROK: 'grok',
   CLAUDE: 'claude',
   GOOGLE: 'google',
-  GITHUB_COPILOT: 'githubcopilot'
+  GITHUB_COPILOT: 'githubcopilot',
+  OLLAMA: 'ollama'
 } as const;
 
 // Type helper for type safety
@@ -25,5 +26,6 @@ export const AI_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   [AI_PROVIDERS.GROK]: 'Grok (xAI)',
   [AI_PROVIDERS.CLAUDE]: 'Claude (Anthropic)',
   [AI_PROVIDERS.GOOGLE]: 'Google',
-  [AI_PROVIDERS.GITHUB_COPILOT]: 'GitHubCopilot'
+  [AI_PROVIDERS.GITHUB_COPILOT]: 'GitHubCopilot',
+  [AI_PROVIDERS.OLLAMA]: 'Ollama'
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,11 +115,16 @@ export class Main {
 
         if (this.isDebugMode) {
             // Debug 模式：從環境變數讀取
-            const modelName = process.env.ModelName ?? DEFAULT_MODELS[providerLower] ?? 'gemini-2.5-flash';
+            const modelName = process.env.ModelName ?? DEFAULT_MODELS[providerLower] ?? '';
             const envKey = API_KEY_ENV_MAP[providerLower];
             const modelKey = envKey ? (process.env[envKey] ?? '') : '';
             const githubToken = providerLower === AI_PROVIDERS.GITHUB_COPILOT ? process.env.GitHubCopilotToken : undefined;
-            const serverAddress = providerLower === AI_PROVIDERS.GITHUB_COPILOT ? process.env.GitHubCopilotServerAddress : undefined;
+            let serverAddress: string | undefined;
+            if (providerLower === AI_PROVIDERS.GITHUB_COPILOT) {
+                serverAddress = process.env.GitHubCopilotServerAddress;
+            } else if (providerLower === AI_PROVIDERS.OLLAMA) {
+                serverAddress = process.env.OllamaBaseUrl;
+            }
             const copilotCliPath = providerLower === AI_PROVIDERS.GITHUB_COPILOT ? process.env.GitHubCopilotCliPath : undefined;
             return { modelName, modelKey, githubToken, serverAddress, copilotCliPath };
         } else {

--- a/src/services/ai-provider.service.ts
+++ b/src/services/ai-provider.service.ts
@@ -12,8 +12,8 @@ import { AI_PROVIDERS } from '../constants';
  * 統一管理所有 AI 服務的建立和存取
  */
 export class AIProviderService {
-    readonly services: Map<string, AIService>;
-    readonly configs: Map<string, AIServiceConfig>;
+    private readonly services: Map<string, AIService>;
+    private readonly configs: Map<string, AIServiceConfig>;
 
     /**
      * 建立 AI 服務提供者實例

--- a/src/services/ai-provider.service.ts
+++ b/src/services/ai-provider.service.ts
@@ -4,6 +4,7 @@ import { OpenAIService } from './openai.service';
 import { GrokService } from './grok.service';
 import { ClaudeService } from './claude.service';
 import { GithubCopilotService } from './github-copilot.service';
+import { OllamaService } from './ollama.service';
 import { AI_PROVIDERS } from '../constants';
 
 /**
@@ -11,8 +12,8 @@ import { AI_PROVIDERS } from '../constants';
  * 統一管理所有 AI 服務的建立和存取
  */
 export class AIProviderService {
-    private services: Map<string, AIService>;
-    private configs: Map<string, AIServiceConfig>;
+    readonly services: Map<string, AIService>;
+    readonly configs: Map<string, AIServiceConfig>;
 
     /**
      * 建立 AI 服務提供者實例
@@ -31,8 +32,8 @@ export class AIProviderService {
     public registerService(provider: string, config: AIServiceConfig): void {
         const providerLower = provider.toLowerCase();
 
-        // GitHub Copilot 不需要 apiKey，serverAddress 也是可選的（未提供時使用本機 CLI）
-        if (providerLower !== AI_PROVIDERS.GITHUB_COPILOT) {
+        // GitHub Copilot 和 Ollama 不需要 apiKey
+        if (providerLower !== AI_PROVIDERS.GITHUB_COPILOT && providerLower !== AI_PROVIDERS.OLLAMA) {
             if (!config.apiKey || config.apiKey.trim() === '') {
                 throw new Error('⛔ API key is required');
             }
@@ -83,6 +84,9 @@ export class AIProviderService {
                 // githubToken, serverAddress, timeout 和 copilotCliPath 是可選的
                 // 未提供時使用本機 CLI 和預設超時
                 service = new GithubCopilotService(config.githubToken, config.serverAddress, config.modelName, config.timeout, config.copilotCliPath);
+                break;
+            case AI_PROVIDERS.OLLAMA:
+                service = new OllamaService(config.modelName, config.serverAddress || 'http://localhost:11434');
                 break;
             default:
                 throw new Error(`⛔ Unsupported AI provider: ${provider}`);

--- a/src/services/base-http-ai.service.ts
+++ b/src/services/base-http-ai.service.ts
@@ -35,6 +35,7 @@ export abstract class BaseHttpAIService extends BaseAIService {
             const requestBody = this.getRequestBody(systemInstruction, prompt, config);
             const headers = this.getHeaders();
             const requestOptions = {
+                ...this.getExtraAxiosConfig(),
                 headers: headers
             };
 
@@ -108,6 +109,14 @@ export abstract class BaseHttpAIService extends BaseAIService {
      * 取得請求 Headers (由子類別實作)
      */
     protected abstract getHeaders(): any;
+
+    /**
+     * 取得額外的 Axios 請求設定（子類別可選擇性覆寫）
+     * @returns 額外的 axios config，例如 timeout
+     */
+    protected getExtraAxiosConfig(): Record<string, any> {
+        return {};
+    }
 
     /**
      * 從回應中提取內容 (由子類別實作)

--- a/src/services/ollama.service.ts
+++ b/src/services/ollama.service.ts
@@ -1,0 +1,91 @@
+import { GenerateConfig } from '../interfaces/ai-service.interface';
+import { BaseHttpAIService } from './base-http-ai.service';
+
+/**
+ * Ollama 地端 AI 服務實作
+ * 使用 Ollama REST API 生成內容
+ */
+export class OllamaService extends BaseHttpAIService {
+    private readonly baseUrl: string;
+
+    /**
+     * 建立 Ollama 服務實例
+     * @param model - 模型名稱（例如 'gemma3:27b'）
+     * @param baseUrl - Ollama API 基礎 URL，預設為 'http://localhost:11434'
+     */
+    constructor(model: string, baseUrl: string = 'http://localhost:11434') {
+        super('local', model);
+        const parsed = new URL(baseUrl); // 若格式非法會直接 throw
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+            throw new Error(`⛔ Ollama baseUrl only allows http:// or https:// protocol`);
+        }
+        this.baseUrl = baseUrl.replace(/\/$/, '');
+    }
+
+    /**
+     * 取得服務名稱
+     * @returns 服務名稱
+     */
+    protected getServiceName(): string {
+        return 'Ollama';
+    }
+
+    protected getApiUrl(): string {
+        return `${this.baseUrl}/api/chat`;
+    }
+
+    protected getHeaders(): any {
+        return {
+            'Content-Type': 'application/json'
+        };
+    }
+
+    protected getRequestBody(
+        systemInstruction: string,
+        prompt: string,
+        config?: GenerateConfig
+    ): any {
+        const messages: Array<{ role: string; content: string }> = [];
+
+        if (systemInstruction && systemInstruction.trim() !== '') {
+            messages.push({ role: 'system', content: systemInstruction });
+        }
+
+        messages.push({ role: 'user', content: prompt });
+
+        const requestBody: any = {
+            model: this.model,
+            messages,
+            stream: false,
+            think: false   // Disable thinking mode for reasoning models
+        };
+
+        const options: Record<string, any> = {};
+        if (config?.temperature !== undefined) {
+            options.temperature = config.temperature;
+        }
+        // Default to 4096 to ensure reasoning models have enough tokens for the content field
+        options.num_predict = config?.maxOutputTokens ?? 4096;
+        requestBody.options = options;
+
+        return requestBody;
+    }
+
+    protected extractContent(response: any): string {
+        const msg = response.data?.message;
+        // Reasoning models (e.g. DeepSeek-R1 style) output thinking separately from content.
+        // If content is empty, fall back to thinking field.
+        return msg?.content || msg?.thinking || '';
+    }
+
+    protected extractTokenUsage(response: any): { inputTokens?: number; outputTokens?: number } {
+        return {
+            inputTokens: response.data.prompt_eval_count,
+            outputTokens: response.data.eval_count
+        };
+    }
+
+    protected override getExtraAxiosConfig(): Record<string, any> {
+        return { timeout: 300_000 };
+    }
+}

--- a/src/services/ollama.service.ts
+++ b/src/services/ollama.service.ts
@@ -61,11 +61,11 @@ export class OllamaService extends BaseHttpAIService {
         };
 
         const options: Record<string, any> = {};
-        if (config?.temperature !== undefined) {
+        if (config?.temperature !== undefined)
             options.temperature = config.temperature;
-        }
-        // Default to 4096 to ensure reasoning models have enough tokens for the content field
-        options.num_predict = config?.maxOutputTokens ?? 4096;
+        if (config?.maxOutputTokens !== undefined)
+            options.num_predict = config?.maxOutputTokens;
+
         requestBody.options = options;
 
         return requestBody;

--- a/src/task.json
+++ b/src/task.json
@@ -12,8 +12,8 @@
     "author": "Lawrence Shen",
     "version": {
         "Major": 2,
-        "Minor": 0,
-        "Patch": 6
+        "Minor": 1,
+        "Patch": 0
     },
     "instanceNameFormat": "PR AutoReview-$(inputAiProvider)",
     "inputs": [
@@ -29,7 +29,8 @@
                 "OpenAI": "OpenAI",
                 "Grok": "Grok (xAI)",
                 "Claude": "Claude (Anthropic)",
-                "GitHubCopilot": "GitHub Copilot"
+                "GitHubCopilot": "GitHub Copilot",
+                "Ollama": "Ollama (Local)"
             }
         },
         {
@@ -148,6 +149,24 @@
             "required": false,
             "helpMarkDown": "Request timeout in milliseconds for GitHub Copilot. Default: 300000 ms (5 minutes).",
             "visibleRule": "inputAiProvider == GitHubCopilot"
+        },
+        {
+            "name": "inputOllamaModelName",
+            "type": "string",
+            "label": "Ollama Model Name",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Enter the Ollama model name (e.g. llama3.2:3b, gemma3:27b).",
+            "visibleRule": "inputAiProvider == Ollama"
+        },
+        {
+            "name": "inputOllamaBaseUrl",
+            "type": "string",
+            "label": "Ollama Base URL",
+            "defaultValue": "http://localhost:11434",
+            "required": false,
+            "helpMarkDown": "Enter the Ollama server base URL. Default: http://localhost:11434",
+            "visibleRule": "inputAiProvider == Ollama"
         },
         {
             "name": "inputMaxOutputTokens",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "ai-pr-autoreview",
     "name": "AutoCodeReview.ai",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "publisher": "LawrenceShen",
     "description": "Automated Code Review for Pull Requests. Supports GitHub Copilot, OpenAI, Google Gemini, Claude, and Grok. Bring your own AI subscription to Azure DevOps.",
     "public": true,


### PR DESCRIPTION
# Release v2.1.0

> **發布日期 (Date):** 2026-04-20
>
> **主要亮點 (Highlights):**
> - 新增 Ollama 地端模型支援，讓使用者無需 API Key 即可在本機或內部伺服器自架 AI 進行 PR 審查，保護程式碼隱私。
> - EN: Introduces self-hosted Ollama as a new AI provider, enabling private, on-premises PR reviews with any Ollama-compatible model — no API key required.

---

## 🌟 What's New / 主要更新

### 🚀 Features / 新功能

* **新增 Ollama AI Provider 支援**：新增 `OllamaService`，透過 Ollama REST API (`/api/chat`) 與地端或自架模型溝通。支援任意 Ollama 相容模型（如 `gemma3:27b`、`llama3.2:3b`）。無需 API Key，僅需設定 `OllamaBaseUrl`（預設 `http://localhost:11434`）。已整合至 Azure DevOps Pipeline Task UI，可在 `inputAiProvider` 選擇 `Ollama (Local)`，並設定 `inputOllamaModelName` 與 `inputOllamaBaseUrl`。對於使用推理模型（如 DeepSeek-R1 風格）的場景，回應解析時若 `content` 為空會自動 fallback 至 `thinking` 欄位。
  > EN: Adds `OllamaService` which communicates with local or self-hosted models via the Ollama REST API (`/api/chat`). Supports any Ollama-compatible model (e.g. `gemma3:27b`, `llama3.2:3b`). No API key required — only `OllamaBaseUrl` needs to be set (defaults to `http://localhost:11434`). Integrated into the Azure DevOps Pipeline Task UI under `inputAiProvider = Ollama (Local)`. For reasoning models (e.g. DeepSeek-R1 style), the response parser automatically falls back to the `thinking` field if `content` is empty.

---

### 🛠 Refactoring & Improvements / 重構與效能優化

* **`BaseHttpAIService` 新增 `getExtraAxiosConfig()` 擴充點**：在 HTTP 請求建構流程中加入可選覆寫方法 `getExtraAxiosConfig()`，讓子類別可注入額外的 axios 設定（如 `timeout`）。`OllamaService` 已透過此機制設定 `timeout: 300_000`（5 分鐘），避免地端大型模型推論超時。
  > EN: Adds an optional override hook `getExtraAxiosConfig()` to `BaseHttpAIService`, allowing subclasses to inject additional axios config (e.g., `timeout`). `OllamaService` uses this to set a 5-minute timeout, preventing inference timeouts with large local models.

* **`AIProviderService` 的 `services` 與 `configs` 屬性由 `private` 改為 `readonly`**：提升對外可存取性，方便測試與擴充場景直接讀取已註冊的服務實例與設定。
  > EN: Changed `services` and `configs` maps in `AIProviderService` from `private` to `readonly`, improving accessibility for testing and extension scenarios where direct inspection of registered services is needed.

---

### 🐛 Bug Fixes / 問題修復

* 無 / None

---

### ⚠️ Breaking Changes / 重大變更

* 無 / None
